### PR TITLE
Fixed extraction of variables from eqs

### DIFF
--- a/src/MomentClosure.jl
+++ b/src/MomentClosure.jl
@@ -5,7 +5,7 @@ import Catalyst: species, params, reactions, speciesmap, paramsmap, numspecies, 
 
 using Reexport
 using ModelingToolkit
-using ModelingToolkit: value
+using ModelingToolkit: value, var_from_nested_derivative
 @reexport using ModelingToolkit: @parameters
 @reexport using Symbolics: @variables
 

--- a/src/central_moment_equations.jl
+++ b/src/central_moment_equations.jl
@@ -165,7 +165,6 @@ function generate_central_moment_eqs(rn::Union{ReactionSystem, ReactionSystemMod
         push!(eqs, D(M[i]) ~ dM[i])
     end
 
-    #vars = extract_variables(eqs, params(rn))
     vars = extract_variables(eqs, N, q_order)
     odes = ODESystem(eqs, rn.iv, vars, rn.ps)
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -145,10 +145,18 @@ function extract_variables(eqs::Array{Equation, 1}, N::Int, q_order::Int)
     iters = construct_iter_all(N, q_order)
     iter_μ = filter(x -> sum(x) > 0, iters)
     iter_M = filter(x -> sum(x) > 1, iters)
+
     μs = values(define_μ(N, q_order, iter_μ))
     Ms = values(define_M(N, q_order, iter_M))
     vars = vcat(μs..., Ms...)
+
+    # extract variables from rhs of each equation
     eq_vars = unique(vcat(get_variables.(eqs)...))
+    # need this as get_variables does not extract var from `Differential(t)(var(t))`
+    diff_vars = [var_from_nested_derivative(eq.lhs)[1] for eq in eqs]
+    # filter out the unique ones
+    eq_vars = unique(vcat(eq_vars..., diff_vars...))
+    # this should preserve the correct ordering
     vars = intersect!(vars, eq_vars)
 
     vars

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -139,7 +139,7 @@ function sample_cumulants(sol::EnsembleSolution, order::Int; naive::Bool=true)
 end
 
 
-function deterministic_IC(μ₀::Vector, eqs::MomentEquations)
+function deterministic_IC(μ₀::Array{T, 1}, eqs::MomentEquations) where T<:Real
 
     # sys as an argument is not strictly needed but it helps to implement checks that all arguments are consistent
     # closed_sys also needs to be included in case bernoulli variables were eliminated (so sys and closed_sys have a different no. of states)
@@ -153,7 +153,7 @@ function deterministic_IC(μ₀::Vector, eqs::MomentEquations)
     odes = eqs.odes
     N = sys.N
     if N != length(μ₀)
-        error("length of μ₀ and number of species in the system are inconsistent")
+        error("length of the passed IC vector and the number of species in the system are inconsistent")
     end
 
     μ_map = [sys.μ[iter] => μ₀[i] for (i, iter) in enumerate(sys.iter_1)]


### PR DESCRIPTION
Fixes [issue #2](https://github.com/augustinas1/MomentClosure.jl/issues/2#issue-828557653).

Internal `extract_variables` was broken, leading to improperly setup `ODESystem`.
Also `deterministic_IC` now enforces the initial condition vector to be strictly an array of Real type (hopefully will work).