### PR TITLE
added missing case(s) in propensity parsing step

### DIFF
--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -224,6 +224,11 @@ function polynomial_propensities(a::Vector, rn::Union{ReactionSystem, ReactionSy
             push!(all_factors[rind], expr)
             push!(all_powers[rind], zeros(Int, N))
 
+        elseif expr in Set(vars) # less conservative but likely faster: expr isa Term
+
+            push!(all_factors[rind], 1)
+            push!(all_powers[rind], map(v -> isequal(expr, v), vars))
+
         elseif operation(expr) == ^ #Symbolics.Pwr
 
             try
@@ -277,6 +282,10 @@ function polynomial_propensities(a::Vector, rn::Union{ReactionSystem, ReactionSy
                     end
                 end
             end
+
+        else
+
+            error("Expression $expr could not be parsed correctly!")
 
         end
 

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -224,7 +224,7 @@ function polynomial_propensities(a::Vector, rn::Union{ReactionSystem, ReactionSy
             push!(all_factors[rind], expr)
             push!(all_powers[rind], zeros(Int, N))
 
-        elseif expr in Set(vars) # less conservative but likely faster: expr isa Term
+        elseif isvar(expr, vars)
 
             push!(all_factors[rind], 1)
             push!(all_powers[rind], map(v -> isequal(expr, v), vars))

--- a/test/moment_equations_tests.jl
+++ b/test/moment_equations_tests.jl
@@ -44,6 +44,14 @@ expr2 = c₂*μ[2,0] + c₁*μ[1,1]/Ω^2 - c₁*μ[3,1]/Ω^2 -c₂*(μ[1,0] + μ
 expr2 = simplify(value.(expr2))
 @test isequal(expand(expr1), expand(expr2))
 
+# corner case - a linear propensity with rate coefficient 1
+rn = @reaction_network begin
+    1, X → 0
+end
+sys = generate_raw_moment_eqs(rn, 2)
+μ = sys.μ
+@test isequal(MomentClosure.Differential(t)(μ[(1,)]) ~ -μ[(1,)], sys.odes.eqs[1])
+
 # time-dependent propensity tests
 
 rn = @reaction_network begin


### PR DESCRIPTION
Hey! 
It seems the parsing step for the propensities is currently missing a (corner) case. Specifically, linear propensities with rate coefficient 1 are not parsed correctly as the resultant expression is a Term and not of type Mul, Pow, etc. 

As a minimal example

rn = @reaction_network begin 1, P --> \emptyset end 

will currently cause an uninformative error upon generation of the associated moment equations. But more importantly reactions of this form will be omitted entirely without error messages if other reactions which can be parsed correctly are present.

Since there is an obvious workaround, I optedt to submit this pull request instead of opening an issue. I also added a case to catch any unparsed expressions in case there are other corner cases that went unnoticed so far. 

Cheers,
Flemming
