### PR TITLE
Migrate CI to centralized SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,11 @@ updates:
       all-julia-packages:
         patterns:
           - "*"
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "daily"
+    groups:
+      all-julia-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,21 +12,9 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: 'lts'
-      - uses: julia-actions/cache@v3
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: Build and deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia --project=docs/ docs/make.jl
+  documentation:
+    name: "Documentation"
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    with:
+      coverage: false
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Downgrade
 on:
   pull_request:
     branches:
@@ -16,9 +16,10 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  tests:
-    name: "Tests"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+  downgrade:
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: '["lts", "1", "pre"]'
+      julia-version: "lts"
+      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -9,12 +9,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,9 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,12 @@
+# Configuration for crate-ci/typos. Only clear false positives are listed here.
+[default.extend-words]
+# "2nd"/"nd" ordinal suffix used throughout (e.g. `iter_2nd_order`, "$2$nd order").
+nd = "nd"
+# `setp` is a SymbolicIndexingInterface API function, not a typo of "step".
+setp = "setp"
+# `arange` is numpy's `np.arange`, used in example notebooks.
+arange = "arange"
+
+[files]
+# Generated SVG plot assets contain text fragments that trip the spell checker.
+extend-exclude = ["docs/src/assets/*.svg"]


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Normalizes this repo's CI to the SciML standard set of centralized reusable workflows in `SciML/.github` (every caller pinned `@v1`, `secrets: inherit`).

## Workflows converted
- **CI / Tests** (`ci.yml`): converted from a hand-rolled matrix job to a `tests.yml@v1` caller. Preserves the exact matrix `julia-version: ["lts", "1", "pre"]` (single `ubuntu-latest`, no test groups) and keeps coverage collection (the original ran `julia-processcoverage` + codecov), which is the reusable workflow's default. `on:`/`concurrency:`/`paths-ignore: docs/**` preserved.
- **Documentation** (`Documentation.yml`): converted to a `documentation.yml@v1` caller with `coverage: false` (the original docs build did not collect coverage). `on:`/`concurrency:` preserved.
- **Runic** (`FormatCheck.yml`): the repo already ran Runic via `fredrikekre/runic-action`; centralized to a `runic.yml@v1` caller. **No formatting changes were needed** (repo was already Runic-formatted).

## Workflows added (newly missing standard checks)
- **SpellCheck** (`SpellCheck.yml`): `spellcheck.yml@v1` (crate-ci/typos).
- **Downgrade** (`Downgrade.yml`): `downgrade.yml@v1` (`julia-version: lts`, `skip: Pkg,TOML`).

## Dependabot
- Existing `github-actions` (weekly) and `julia` (daily, grouped) blocks preserved.
- Added a `julia` block for `/docs` (it has its own `Project.toml`).
- No CompatHelper present, so nothing to remove. No `crate-ci/typos` ignore block existed.

## SpellCheck findings
Added a minimal `_typos.toml` for clear false positives only (no prose was mass-edited):
- `nd` — the `2nd` ordinal suffix used throughout (e.g. `iter_2nd_order`, "$2$nd order").
- `setp` — a real SymbolicIndexingInterface API function.
- `arange` — numpy `np.arange` in example notebooks.
- Excludes generated `docs/src/assets/*.svg` plot assets.

The following look like **genuine typos** and were left for a maintainer to fix (the SpellCheck check will flag them until then):
- `src/closure_methods/linear_mapping_approximation.jl:97` — `dependendent` -> `dependent`
- `docs/src/tutorials/using_momentclosure.md:198` — `occurence` -> `occurrence`
- `examples/conditional_TEST_J.ipynb` — `scenarion` -> `scenario`, `occurence` -> `occurrence`
- `examples/Brusselator.ipynb:248` — `occurence` -> `occurrence`
- `examples/P53 system.ipynb:395` — `remaning` -> `remaining`
- `examples/noisy_lotka_volterra.ipynb:229` — `ba` -> `by`/`be`

## Heads-up
The job/check names change (now `Tests`, `Documentation`, `Runic`, `Spell Check`, `Downgrade` via reusable workflows). **Branch-protection required-status-checks will need to be updated** to match the new check names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)