### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,10 @@
+name: "Doc Preview Cleanup"
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+jobs:
+  cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Adds the missing standard SciML centralized caller workflows to this repo. Existing workflows are untouched.

Added:
- `RunicSuggestions.yml` — auto-format suggestions on PRs (repo is Runic-based) via `runic-suggestions-on-pr.yml@v1`
- `DependabotAutoMerge.yml` — Dependabot auto-merge via `dependabot-automerge.yml@v1`
- `DocPreviewCleanup.yml` — docs preview cleanup on PR close via `docs-preview-cleanup.yml@v1` (repo has a `docs/` Documenter site)

These are static caller files referencing the centralized SciML/.github reusable workflows; no local test runs are applicable.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
