### PR TITLE
Fix spelling typos and ignore notebook cell ids in typos config

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,9 @@
 # Configuration for crate-ci/typos. Only clear false positives are listed here.
+[default]
+# Jupyter notebook cell ids are opaque hex hashes (e.g. "365e5ba2"); their
+# fragments are not words and routinely collide with the dictionary.
+extend-ignore-re = ['"id": "[0-9a-f]+"']
+
 [default.extend-words]
 # "2nd"/"nd" ordinal suffix used throughout (e.g. `iter_2nd_order`, "$2$nd order").
 nd = "nd"

--- a/docs/src/api/momentclosure_api.md
+++ b/docs/src/api/momentclosure_api.md
@@ -5,7 +5,7 @@ CurrentModule = MomentClosure
 
 ## Model Definition
 
-MomentClosure is fully compatible with reaction network models defined using [Catalyst](https://github.com/SciML/Catalyst.jl) and stored as a [`Catalyst.ReactionSystem`](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.ReactionSystem). Note that previously we had implemented our own `ReactionSystemMod`, that allowed us to consider systems containing reactions which products are independent geometrically distributed random variables. However, this is now deprecated as Catalyst has added support for such parameteric stoichiometries offering a much more complete and efficient feature set.
+MomentClosure is fully compatible with reaction network models defined using [Catalyst](https://github.com/SciML/Catalyst.jl) and stored as a [`Catalyst.ReactionSystem`](https://docs.sciml.ai/Catalyst/stable/api/core_api/#Catalyst.ReactionSystem). Note that previously we had implemented our own `ReactionSystemMod`, that allowed us to consider systems containing reactions which products are independent geometrically distributed random variables. However, this is now deprecated as Catalyst has added support for such parametric stoichiometries offering a much more complete and efficient feature set.
 
 ## [Basic Model Properties](@id api-basic-network-properties)
 

--- a/docs/src/tutorials/using_momentclosure.md
+++ b/docs/src/tutorials/using_momentclosure.md
@@ -195,7 +195,7 @@ dprob = DiscreteProblem(jsys, u0map, tspan, pmap) # same parameters as defined e
 
 # create a JumpProblem: specify Gillespie's Direct Method as the solver
 # and SET save_positions to (false, false) as otherwise time of each
-# reaction occurence would be saved (complicating moment estimates)
+# reaction occurrence would be saved (complicating moment estimates)
 jprob = JumpProblem(jsys, dprob, Direct(), save_positions=(false, false))
 
 # define an EnsembleProblem to simulate multiple trajectories

--- a/examples/Brusselator.ipynb
+++ b/examples/Brusselator.ipynb
@@ -245,7 +245,7 @@
     "\n",
     "# create a JumpProblem: specify Gillespie's Direct Method as the solver\n",
     "# and SET save_positions to (false, false) as otherwise time of each\n",
-    "# reaction occurence would be saved (complicating moment estimates)\n",
+    "# reaction occurrence would be saved (complicating moment estimates)\n",
     "jprob = JumpProblem(jsys, dprob, Direct(), save_positions=(false, false))\n",
     "\n",
     "# define an EnsembleProblem to simulate multiple trajectories\n",

--- a/examples/P53 system.ipynb
+++ b/examples/P53 system.ipynb
@@ -392,7 +392,7 @@
    "outputs": [],
    "source": [
     "# checking the trajectories using the QNDF (or ode15s) solve which is the default MEANS solver\n",
-    "# slight differences remaning between the trajectory obtained here and the one obtained using MEANS\n",
+    "# slight differences remaining between the trajectory obtained here and the one obtained using MEANS\n",
     "# indicate that the difference lies in the implementation (inclusion of higher-order moment \n",
     "# information in the closure functions)\n",
     "\n",

--- a/examples/conditional_TEST_J.ipynb
+++ b/examples/conditional_TEST_J.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "Generate raw moment equations up to 3rd order.\n",
     "\n",
-    "The argument `combinatoric_ratelaws = false` indicates whether binomial coefficients are included when constructing the propensity functions for the reactions that follow the law of mass action (does not play a role in this specific scenarion)\n",
+    "The argument `combinatoric_ratelaws = false` indicates whether binomial coefficients are included when constructing the propensity functions for the reactions that follow the law of mass action (does not play a role in this specific scenario)\n",
     "\n",
     "Equivalently, central moment equations can be generated using `generate_central_moment_eqs(rn, 3, 5, combinatoric_ratelaws=false)`"
    ]
@@ -281,7 +281,7 @@
     "\n",
     "# create a JumpProblem and specify Gillespie's Direct Method as the solver:\n",
     "jprob = JumpProblem(rn, dprob, Direct(), save_positions=(false, false))\n",
-    "# SET save_positions to (false, false) as otherwise time of each reaction occurence is saved\n",
+    "# SET save_positions to (false, false) as otherwise time of each reaction occurrence is saved\n",
     "\n",
     "dt = 1 # time resolution at which numerical solution is saved\n",
     "\n",

--- a/src/closure_methods/linear_mapping_approximation.jl
+++ b/src/closure_methods/linear_mapping_approximation.jl
@@ -94,6 +94,6 @@ end
 
 #= TODO: consider adding
   • steady-state stuff
-  • identification of whether a linear system has a time-dependendent or steady-state solution
+  • identification of whether a linear system has a time-dependent or steady-state solution
   • construction of probability distributions if a solution exists
 =#


### PR DESCRIPTION
Split out of #96 (the trivial, non-code piece).

## Changes
- Fix spelling typos: `occurence`→`occurrence`, `scenarion`→`scenario`, `remaning`→`remaining`, `parameteric`→`parametric` (docs + example notebooks), and `dependendent`→`dependent` (a comment in `src/closure_methods/linear_mapping_approximation.jl`).
- Add an `extend-ignore-re` to `_typos.toml` so Jupyter notebook cell-id hex hashes (e.g. `"id": "365e5ba2"`) are not flagged as misspellings.

No source logic changes (the one `.jl` edit is a comment typo). Independent of the MTK 11 migration — applies cleanly on top of `main` by itself.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)