### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MomentClosure"
 uuid = "01a1b25a-ecf0-48c5-ae58-55bfd5393600"
 authors = ["Augustinas Sukys"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Automated patch version bump (0.4.2 -> 0.4.3) to release unreleased commits on `main` via JuliaRegistrator.