### PR TITLE
Release prep: bump to 0.4.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MomentClosure"
 uuid = "01a1b25a-ecf0-48c5-ae58-55bfd5393600"
 authors = ["Augustinas Sukys"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"


### PR DESCRIPTION
Version-bump-only release PR. Migrates core imports (get_iv/get_eqs/unknowns/get_ps) from ModelingToolkit to the new split-out ModelingToolkitBase package, which re-exports the same API -- part of the ongoing MTK/MTKBase ecosystem migration seen elsewhere in SciML.