### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -4,7 +4,6 @@ using JET
 run_qa(
     MomentClosure;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true),
     ei_kwargs = (;
         # Genuine non-public internals of non-SciML / not-yet-`public`-declared
         # deps that MomentClosure explicitly imports. Re-checked empirically on

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -3,7 +3,6 @@ using JET
 
 run_qa(
     MomentClosure;
-    explicit_imports = true,
     ei_kwargs = (;
         # Genuine non-public internals of non-SciML / not-yet-`public`-declared
         # deps that MomentClosure explicitly imports. Re-checked empirically on


### PR DESCRIPTION
Removes the redundant rendered-docs override now that SciMLTesting 2.3 enables strict public API rendering by default.

Ignore until reviewed by @ChrisRackauckas.