### PR TITLE
Fix Core test failure: import DiscreteProblem/EnsembleProblem from SciMLBase

### DIFF
--- a/test/sample_moment_tests.jl
+++ b/test/sample_moment_tests.jl
@@ -1,5 +1,6 @@
 using MomentClosure
 using MomentClosure: gen_iter
+using SciMLBase: DiscreteProblem, EnsembleProblem
 using SciMLBase.EnsembleAnalysis, JumpProcesses
 using Test
 


### PR DESCRIPTION
## Failing lanes

On master HEAD (`41d9b5c`) these three checks are red:

- `tests / Core (julia 1, ubuntu-latest) / Tests - Core (Julia 1)`
- `tests / Core (julia lts, ubuntu-latest) / Tests - Core (Julia lts)`
- `tests / Core (julia pre, ubuntu-latest) / Tests - Core (Julia pre)`

All three fail identically in `test/sample_moment_tests.jl`:

```
Core/sample_moment_tests.jl: Error During Test at SafeTestsets.jl:30
  Got exception outside of a @test
  LoadError: UndefVarError: `DiscreteProblem` not defined in `Main.var"##Core/sample_moment_tests.jl#14440"`
  Suggestion: check for spelling errors or missing imports.
  Hint: a global variable of this name also exists in SciMLBase.
      - Also exported by DiffEqBase (loaded but not imported in Main).
      - Also exported by ModelingToolkitBase (loaded but not imported in Main).
      ...
  Stacktrace:
    [1] top-level scope
      @ ~/_work/MomentClosure.jl/MomentClosure.jl/test/sample_moment_tests.jl:20
```

## Root cause

**Not** the two commits since the v0.4.5 release. This is upstream ecosystem drift.

`test/sample_moment_tests.jl` starts with `using SciMLBase.EnsembleAnalysis, JumpProcesses` and then
calls `DiscreteProblem(u₀, tspan, p)` and `EnsembleProblem(jprob)`. Neither name is exported by
`JumpProcesses` itself nor by `SciMLBase.EnsembleAnalysis` — they were reaching the test's scope only
because JumpProcesses used to do `@reexport using DiffEqBase`.

[JumpProcesses v9.29.3](https://github.com/SciML/JumpProcesses.jl/compare/v9.29.2...v9.29.3) removed that:

```diff
-using Reexport: Reexport, @reexport
-@reexport using DiffEqBase
+using DiffEqBase
```

Timeline confirming this is drift rather than a regression from the two new commits:

| | date | JumpProcesses resolved | Core lanes |
|---|---|---|---|
| `8167846` (v0.4.5, baseline) | 2026-08-04 | 9.29.2 | green |
| PR #109 (MTKBase floor 1.35) | 2026-08-14 | 9.29.2 | green |
| JumpProcesses 9.29.3 released | 2026-08-18 | — | — |
| PR #110 (precompile workload) | 2026-08-20 | 9.29.3 | red, same `DiscreteProblem` error |
| master `41d9b5c` | 2026-08-21 | 9.29.3 | red, same error |

PR #110 was already red with this exact error before it was merged, so the precompile workload is not
implicated. The `Downgrade` lane stayed green throughout, which is consistent with a failure that only
appears on the newest resolvable versions. The precompile workload itself builds and runs fine
(`MomentClosure` precompiles cleanly and all closure/moment tests pass), so it is left untouched.

## Fix

One line in the test, matching the explicit-import style already used by `test/moment_ODE_tests.jl`
(`using SciMLBase: ODEProblem`):

```julia
using SciMLBase: DiscreteProblem, EnsembleProblem
```

`solve` is still exported by JumpProcesses directly, so no other name in that file needs re-importing.
No `src/` or `Project.toml` change is required — MomentClosure already depends on SciMLBase, and
`JumpProcesses = "9.29"` remains correct since 9.29.3 is a valid member of that range.

## Verification

Ran the full `Core` group locally on Julia 1.11.8 with JumpProcesses 9.29.3 resolved
(confirmed in the local `Manifest.toml`):

```
Core/basic_symbolic_tests.jl       |  9   9
Core/bernoulli_closure_tests.jl    | 12  12
Core/closure_tests.jl              | 19  19
Core/conditional_closure_tests.jl  | 15  15
Core/latexify_tests.jl             |  3   3
Core/lma_tests.jl                  |  4   4
Core/moment_ODE_tests.jl           |  4   4
Core/moment_convert_tests.jl       |  8   8
Core/moment_equations_SDE_tests.jl | 22  22
Core/moment_equations_tests.jl     | 25  25
Core/reaction_system_tests.jl      |  2   2
Core/sample_moment_tests.jl        |  9   9
     Testing MomentClosure tests passed
```

`Runic --check` reports no diff on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
